### PR TITLE
Provide rust-toolchain file

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -112,18 +112,20 @@
 - [CMake](https://developer.android.com/ndk/guides/cmake). Может быть установлен с помощью Android Studio.
 - [Autotools](https://www.gnu.org/software/automake/faq/autotools-faq.html).
 - [Kotlin](https://developer.android.com/kotlin). Может быть установлен с помощью Android Studio.
-- [Rust](https://www.rust-lang.org/tools/install). Тестировалось на версии **1.51.0**. Необходимо добавить Android цели:
+- [Rust](https://www.rust-lang.org/tools/install). Rustup сам установит необходимые toolchain и цели для кросс компиляции, используя файл [rust-toolchain](rust-toolchain).
+  
+  - Установка Android целей вручную:
 
-```console
-# Android arm64-v8a
-rustup target add aarch64-linux-android
-# Android armeabi-v7a
-rustup target add armv7-linux-androideabi
-# Android x86
-rustup target add i686-linux-android
-# Android x86_64
-rustup target add x86_64-linux-android
-```
+    ```console
+    # Android arm64-v8a
+    rustup target add aarch64-linux-android
+    # Android armeabi-v7a
+    rustup target add armv7-linux-androideabi
+    # Android x86
+    rustup target add i686-linux-android
+    # Android x86_64
+    rustup target add x86_64-linux-android
+    ```
 
 ### Варианты сборки Gradle
 

--- a/README.md
+++ b/README.md
@@ -112,18 +112,20 @@ Use Android Studio and Gradle to build *Seeneva* apk/bundle.
 - [CMake](https://developer.android.com/ndk/guides/cmake). Can be installed using Android Studio.
 - [Autotools](https://www.gnu.org/software/automake/faq/autotools-faq.html).
 - [Kotlin](https://developer.android.com/kotlin). Can be installed using Android Studio.
-- [Rust](https://www.rust-lang.org/tools/install). Tested on **1.51.0**. Also you need to add Android targets:
+- [Rust](https://www.rust-lang.org/tools/install). Rustup will automatically install all required toolchain and targets using [rust-toolchain](rust-toolchain) file.
 
-```console
-# Android arm64-v8a
-rustup target add aarch64-linux-android
-# Android armeabi-v7a
-rustup target add armv7-linux-androideabi
-# Android x86
-rustup target add i686-linux-android
-# Android x86_64
-rustup target add x86_64-linux-android
-```
+  - Android targets manual setup:
+
+    ```console
+    # Android arm64-v8a
+    rustup target add aarch64-linux-android
+    # Android armeabi-v7a
+    rustup target add armv7-linux-androideabi
+    # Android x86
+    rustup target add i686-linux-android
+    # Android x86_64
+    rustup target add x86_64-linux-android
+    ```
 
 ### Gradle build variants
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,11 @@
+# Overrides used Rust toolchain by ./native submodule
+# https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+[toolchain]
+channel = "1.51.0"
+components = ["rustfmt", "clippy", "rls", "rust-analysis"]
+targets = [
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android",
+]


### PR DESCRIPTION
The [rust-toolchain](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) TOML file was added. It will help describe tested toolchain version and auto install required Android targets.

Also it will help F-Droid build process. #4 