### PR TITLE
Fix F-Droid adding issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,7 @@ subprojects {
 
     configure<BaseExtension> {
         //TODO update when fixed https://github.com/android/ndk/issues/1391 or build my own libz?
-        ndkVersion = "21.3.6528147"
+        ndkVersion = "21.4.7075529"
         buildToolsVersion = "30.0.3"
         compileSdkVersion(30)
 


### PR DESCRIPTION
As [noted](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/8835#note_556038868) F-Droid build server doesn't support NDK `r21d`.

Update NDK to LTS version `r21e`.