### PR TITLE
CI changes for a PR from a fork

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -7,8 +7,9 @@ on:
       - dev
 
 env:
-  APP_BUILD_TYPE: "${{ github.base_ref == 'master' && 'Release' || 'Debug' }}"
-  RELEASE_CANDIDATE: "${{ github.base_ref == 'master' && (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/')) }}"
+  FORK: "${{ github.event.pull_request.head.repo.full_name != github.repository }}"
+  APP_BUILD_TYPE: "${{ github.event.pull_request.head.repo.full_name == github.repository && github.base_ref == 'master' && 'Release' || 'Debug' }}"
+  RELEASE_CANDIDATE: "${{ github.event.pull_request.head.repo.full_name == github.repository && github.base_ref == 'master' && (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/')) }}"
   BUNDLE_WITHOUT: development
   FASTLANE_SKIP_UPDATE_CHECK: true
 
@@ -60,10 +61,15 @@ jobs:
       version_code: ${{ steps.bump_version.outputs.version_code }}
     steps:
       - uses: actions/checkout@v2
+        if: ${{ env.RELEASE_CANDIDATE == 'true' }}
         with:
-          # PR check will stuck on 'waiting for status' without PAT
-          token: ${{ env.RELEASE_CANDIDATE == 'true' && secrets.PAT || secrets.GITHUB_TOKEN }}
+          # Reqyured by stefanzweifel/git-auto-commit-action
+          # PR check will stuck on 'waiting for status' without PAT after version bump pushing
+          token: ${{ secrets.PAT }}
           ref: ${{ github.head_ref }}
+
+      - uses: actions/checkout@v2
+        if: ${{ env.RELEASE_CANDIDATE == 'false' }}
 
       - name: Setup required Ruby
         uses: ruby/setup-ruby@v1.70.1
@@ -234,6 +240,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
 
       - name: Run assemble task
+        if: ${{ env.FORK == 'false' }}
         run: |
           bundle exec fastlane pr_build_apk build_type:"${APP_BUILD_TYPE}" store_data:"${SEENEVA_STORE_DATA}"
         env:
@@ -245,6 +252,14 @@ jobs:
           SEENEVA_KEY_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           SEENEVA_KEY_PASS: ${{ secrets.KEY_PASS }}
           FL_GRADLE_PRINT_COMMAND: false
+
+      - name: Run forked assemble task
+        if: ${{ env.FORK == 'true' }}
+        run: |
+          bundle exec fastlane pr_build_fork_apk build_type:"${APP_BUILD_TYPE}"
+        env:
+          SEENEVA_VERSION_NAME: ${{ needs.bump_version.outputs.version_name }}
+          SEENEVA_VERSION_CODE: ${{ needs.bump_version.outputs.version_code }}
 
       - name: Upload APKs
         uses: actions/upload-artifact@v2.2.3

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,6 +74,20 @@ platform :android do
     end
   end
 
+  desc 'Build all APK without splitting by ABI and attach them to GitHub PR'
+  lane :pr_build_fork_apk do |options|
+    clean
+
+    gradle(
+      task: ':app:assemble',
+      build_type: (options[:build_type] || 'Debug'),
+      properties: {
+        'seeneva.disableSplitApk': '',
+        'seeneva.noDebSymbols': ''
+      }
+    )
+  end
+
   desc 'Build GitHub release APKs splitted by ABI'
   lane :gh_release_apk do |options|
     base_build(options) do


### PR DESCRIPTION
A `pull_request` action event from a fork doesn't have access to secrets. So I change this workflow. It should work now.